### PR TITLE
fix wrong typing output path

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -255,7 +255,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
      */
-    "untrimmedFilePath": "<projectFolder>/dist/types/<unscopedPackageName>.d.ts"
+    "untrimmedFilePath": "<projectFolder>/dist/types/index.d.ts"
 
     /**
      * Specifies the output path for a .d.ts rollup file to be generated with trimming for an "alpha" release.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "type": "module",
   "module": "dist/es/index.js",
   "main": "dist/cjs/index.js",
-  "types": "dist/types/height-app-api.d.ts",
+  "types": "dist/types/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
@@ -37,7 +37,7 @@
     "dist/es/height-app-api.mjs.map",
     "dist/es/index.js",
     "dist/es/index.js.map",
-    "dist/types/height-app-api.d.ts"
+    "dist/types/index.d.ts"
   ],
   "devDependencies": {
     "@hyrious/esbuild-plugin-commonjs": "^0.2.2",


### PR DESCRIPTION
This fix the wrong index types file path when referencing using package types config.

![CleanShot 2025-02-18 at 20 03 57](https://github.com/user-attachments/assets/c167c2a5-8f6a-4cd9-8666-ea486b69a4e9)

To fix this, instead we use a consistent typing file `index.d.ts` as the typing entry point.

![CleanShot 2025-02-18 at 20 05 18](https://github.com/user-attachments/assets/595e03d1-e22f-4d7d-8276-cab0443a7e25)



